### PR TITLE
REL-970786 Updated latest Relativity.Server.OutsideIn.FI.Win32.SDK

### DIFF
--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -10,16 +10,16 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Polly" Version="5.7.0" />
-    <PackageReference Include="Relativity.Server.Import.SDK" Version="2.9.2" />
-    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="2.15.6" />
-    <PackageReference Include="Relativity.Server.Logging.Interfaces.SDK" Version="3000.4.1" />
-    <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2023.4.0" />
-    <PackageReference Include="Relativity.Server.Productions.SDK" Version="12.3.0" />
-    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="13.6.1" />
-    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="13.6.1" />
+    <PackageReference Include="Relativity.Server.Import.SDK" Version="24000.0.2-pre.7" />
+    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="24000.0.6" />
+    <PackageReference Include="Relativity.Server.Logging.Interfaces.SDK" Version="5000.1.0" />
+    <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2024.11.0" />
+    <PackageReference Include="Relativity.Server.Productions.SDK" Version="24000.0.0" />
+    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="24000.0.1-pre.1" />
+    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="24000.0.1-pre.1" />
     <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="10.3.0" />
     <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="10.3.0" />
-    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="7.7.0" />
+    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="24000.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Docs\EDRM-Sample1.pdf">

--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -10,16 +10,16 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Polly" Version="5.7.0" />
-    <PackageReference Include="Relativity.Server.Import.SDK" Version="24000.0.2-pre.7" />
-    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="24000.0.6" />
-    <PackageReference Include="Relativity.Server.Logging.Interfaces.SDK" Version="5000.1.0" />
+    <PackageReference Include="Relativity.Server.Import.SDK" Version="2.9.2" />
+    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="2.15.6" />
+    <PackageReference Include="Relativity.Server.Logging.Interfaces.SDK" Version="3000.4.4" />
     <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2024.11.0" />
-    <PackageReference Include="Relativity.Server.Productions.SDK" Version="24000.0.0" />
-    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="24000.0.1-pre.1" />
-    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="24000.0.1-pre.1" />
+    <PackageReference Include="Relativity.Server.Productions.SDK" Version="12.3.0" />
+    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="13.6.1" />
+    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="13.6.1" />
     <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="10.3.0" />
     <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="10.3.0" />
-    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="24000.0.1" />
+    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="7.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Docs\EDRM-Sample1.pdf">

--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Polly" Version="5.7.0" />
     <PackageReference Include="Relativity.Server.Import.SDK" Version="2.9.2" />
     <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="2.15.6" />
-    <PackageReference Include="Relativity.Server.Logging.Interfaces.SDK" Version="3000.4.4" />
     <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2024.11.0" />
     <PackageReference Include="Relativity.Server.Productions.SDK" Version="12.3.0" />
     <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="13.6.1" />


### PR DESCRIPTION
- REL-970786 Updated the latest Relativity.Server.OutsideIn.FI.Win32.SDK to 24000.11.0
- [Vulnerable OutsideIn library in project server-import-sdk-samples](https://jira.kcura.com/browse/REL-893257)

Test evidence:
<img width="1184" alt="image" src="https://github.com/relativitydev/server-import-sdk-samples/assets/127181474/a4670477-18fa-4a9e-a106-ac238f41213d">
