### PR TITLE
REL-1203498 security fix

### DIFF
--- a/src/Relativity.Server.Import.SDK.Samples/App.config
+++ b/src/Relativity.Server.Import.SDK.Samples/App.config
@@ -107,6 +107,10 @@
         <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.13.3.0" newVersion="3.13.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -10,15 +10,16 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Polly" Version="5.7.0" />
-    <PackageReference Include="Relativity.Server.Import.SDK" Version="24000.1.0" />
-    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="5000.0.2" />
-    <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2024.11.0" />
+    <PackageReference Include="Relativity.Server.Import.SDK" Version="25000.0.16-pre.13" />
+    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="5000.1.4" />
+    <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2025.8.0" /> 
     <PackageReference Include="Relativity.Server.Productions.SDK" Version="24000.0.0" />
-    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="5000.0.2" />
-    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="5000.0.2" />
+    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="5001.1.0" />
+    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="5001.1.0" />
     <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="5000.1.0" />
     <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="5000.1.0" />
-    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="24000.0.1" />
+    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="25000.0.6" />
+    <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Docs\EDRM-Sample1.pdf">

--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -7,18 +7,20 @@
   <ItemGroup>
     <PackageReference Include="NBuilder" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="Polly" Version="5.7.0" />
-    <PackageReference Include="Relativity.Server.Import.SDK" Version="25000.0.16-pre.13" />
+    <PackageReference Include="Relativity.Server.Import.SDK" Version="25000.0.19" />
     <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="5000.1.4" />
     <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2025.8.0" /> 
-    <PackageReference Include="Relativity.Server.Productions.SDK" Version="24000.0.0" />
+    <PackageReference Include="Relativity.Server.Productions.SDK" Version="25000.0.1" />
     <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="5001.1.0" />
     <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="5001.1.0" />
-    <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="5000.1.0" />
-    <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="5000.1.0" />
+    <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="5001.0.38" />
+    <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="5001.0.38" />
     <PackageReference Include="Relativity.Server.Transfer.SDK" Version="25000.0.6" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
+++ b/src/Relativity.Server.Import.SDK.Samples/Relativity.Server.Import.SDK.Samples.csproj
@@ -10,15 +10,15 @@
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="Polly" Version="5.7.0" />
-    <PackageReference Include="Relativity.Server.Import.SDK" Version="2.9.2" />
-    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="2.15.6" />
+    <PackageReference Include="Relativity.Server.Import.SDK" Version="24000.1.0" />
+    <PackageReference Include="Relativity.Server.Kepler.Client.SDK" Version="5000.0.2" />
     <PackageReference Include="Relativity.Server.OutsideIn.FI.Win32.SDK" Version="2024.11.0" />
-    <PackageReference Include="Relativity.Server.Productions.SDK" Version="12.3.0" />
-    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="13.6.1" />
-    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="13.6.1" />
-    <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="10.3.0" />
-    <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="10.3.0" />
-    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="7.7.0" />
+    <PackageReference Include="Relativity.Server.Productions.SDK" Version="24000.0.0" />
+    <PackageReference Include="Relativity.Server.Services.DataContracts.SDK" Version="5000.0.2" />
+    <PackageReference Include="Relativity.Server.Services.Interfaces.SDK" Version="5000.0.2" />
+    <PackageReference Include="Relativity.Server.Testing.Framework.Api.SDK" Version="5000.1.0" />
+    <PackageReference Include="Relativity.Server.Testing.Framework.SDK" Version="5000.1.0" />
+    <PackageReference Include="Relativity.Server.Transfer.SDK" Version="24000.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\Docs\EDRM-Sample1.pdf">


### PR DESCRIPTION
- Added a binding redirect for System.Runtime.CompilerServices.Unsafe from versions 0.0.0.0–6.0.0.0 to 6.0.0.0.
- NUnit upgraded from 3.13.3 → 4.2.2.
- NUnit3TestAdapter from 4.4.2 → 6.0.1.
- Relativity.Server.Import.SDK from 25000.0.16-pre.13 → 25000.0.19.
- Relativity.Server.Productions.SDK from 24000.0.0 → 25000.0.1.
- Relativity.Server.Testing.Framework.Api.SDK and Relativity.Server.Testing.Framework.SDK from 5000.1.0 → 5001.0.38.
- System.Net.Http version 4.3.4
- System.Runtime.CompilerServices.Unsafe version 6.0.0